### PR TITLE
设置图示文字背景

### DIFF
--- a/background.js
+++ b/background.js
@@ -41,6 +41,7 @@ function doAction(tabId, act, flag, url, data) {
 
 // 設定圖示上的文字
 function iconActionStat() {
+	chrome.browserAction.setBadgeBackgroundColor({'color': '#C0C0C0'});
 	switch (tongwen.iconAction) {
 		case 'trad': chrome.browserAction.setBadgeText({'text': 'T'}); break;
 		case 'simp': chrome.browserAction.setBadgeText({'text': 'S'}); break;


### PR DESCRIPTION
把图示文字背景设置为灰色，为了不要分散注意力。
